### PR TITLE
Improve regexp pattern for matching negative values in viewbox attribute

### DIFF
--- a/bin/svg.js
+++ b/bin/svg.js
@@ -117,7 +117,7 @@ golb(filepath, function (err, files) {
 
     svgo.optimize(content, (result) => {
       let data = result.data.replace(/<svg[^>]+>/gi, '').replace(/<\/svg>/gi, '')
-      let viewBox = result.data.match(/viewBox="([\d\.]+\s[\d\.]+\s[\d\.]+\s[\d\.]+)"/)
+      let viewBox = result.data.match(/viewBox="([-\d\.]+\s[-\d\.]+\s[-\d\.]+\s[-\d\.]+)"/)
 
       if (viewBox && viewBox.length > 1) {
         viewBox = `'${viewBox[1]}'`


### PR DESCRIPTION
Negative values weren't matched (despite being valid) in viewBox svg attribute.
This fix a build fail when no value were inserted in place of viewbox key in each generated icons
![screen shot 2017-05-12 at 17 55 23](https://cloud.githubusercontent.com/assets/4596409/26018371/8c341a00-373c-11e7-9ced-a74456ac606b.png)
