### PR TITLE
Rely on svg for height and width if no viewBox set

### DIFF
--- a/bin/svg.js
+++ b/bin/svg.js
@@ -143,8 +143,6 @@ glob(sourcePath, function (err, files) {
 
       if (viewBox && viewBox.length > 1) {
         viewBox = `'${viewBox[1]}'`
-      } else {
-        viewBox = `'0, 0, 200, 200'`
       }
 
       // add pid attr, for css
@@ -164,7 +162,7 @@ glob(sourcePath, function (err, files) {
           name: `${filePath}${name}`,
           width: parseFloat(result.info.width) || 16,
           height: parseFloat(result.info.height) || 16,
-          viewBox: viewBox,
+          viewBox: `${viewBox}`,
           data: data
       })
 


### PR DESCRIPTION
Should not default viexBox to `0, 0, 200, 200` if svg don't provide a viexBox property.