### PR TITLE
Double fill or stroke property fix

### DIFF
--- a/component/svgicon.vue
+++ b/component/svgicon.vue
@@ -115,7 +115,10 @@
             pathData = addOriginalColor(pathData)
           }
 
-          if (this.colors && this.colors.length > 0) {
+          if (!/ fill="| stroke="/.test(pathData) && 
+            this.colors &&
+            this.colors.length > 0
+          ) {
             pathData = addColor(pathData)
           }
 


### PR DESCRIPTION
Hi.
I've noticed that `vue-svgicon` don't work in IE11 even with polyfill. I've found out that when you using `original` prop, it gives double `fill` or `stroke` property in XML: one from `addOriginalColor` and one from `addColor`, and xml parser in polyfill will throw an exception about invalid XML data.