### PR TITLE
typescript support : default export of VueSvgIcon class

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,4 +21,4 @@ declare class VueSvgIcon extends Vue {
     }>
 }
 
-export = VueSvgIcon
+export default VueSvgIcon


### PR DESCRIPTION
The class could not be reached via `export =`, I am not even sure how it worked for other people.

I believe the correct syntax should be `export default`

After changing this, it worked for me.