### PR TITLE
Remove empty first line from icon templates

### DIFF
--- a/default/icon.tpl.es6.txt
+++ b/default/icon.tpl.es6.txt
@@ -1,4 +1,3 @@
-
 /* eslint-disable */
 /* tslint:disable */
 // @ts-ignore

--- a/default/icon.tpl.txt
+++ b/default/icon.tpl.txt
@@ -1,4 +1,3 @@
-
 /* eslint-disable */
 var icon = require('vue-svgicon')
 icon.register({


### PR DESCRIPTION
Hello!
Didn't find any reason for empty line sitting at the top of default icon templates so I removed them because after update to v3 my previously generated icons changed.
If there is one, I'll be glad to know about it!