### PR TITLE
Update innersvg-polyfill.js

### DIFF
--- a/polyfill/innersvg-polyfill.js
+++ b/polyfill/innersvg-polyfill.js
@@ -77,7 +77,7 @@ module.exports = function() {
                 dXML.async = false
                 // Wrap the markup into a SVG node to ensure parsing works.
                 var sXML =
-                    "<svg xmlns='http://www.w3.org/2000/svg'>" +
+                    "<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'>" +
                     markupText +
                     '</svg>'
 


### PR DESCRIPTION
I am using Vue-svgicon with  polyfil for IE11,
On certain SVG's I am getting the error below:

This happens when XML strings are self closing. 
There is a pending PR regarding the same. 
https://github.com/dnozay/innersvg-polyfill/pull/1

> [Vue warn]: Error in nextTick: "Error: Error parsing XML string"
> 
> [object DOMException]{ABORT_ERR: 20, code: 12, constructor: DOMException {...}, DATA_CLONE_ERR: 25, DOMSTRING_SIZE_ERR: 2, HIERARCHY_REQUEST_ERR: 3, INDEX_SIZE_ERR: 1, INUSE_ATTRIBUTE_ERR: 10, INVALID_ACCESS_ERR: 15, INVALID_CHARACTER_ERR: 5, INVALID_MODIFICATION_ERR: 13, INVALID_NODE_TYPE_ERR: 24, INVALID_STATE_ERR: 11, message: "SyntaxError", name: "SyntaxError", NAMESPACE_ERR: 14, NETWORK_ERR: 19, NO_DATA_ALLOWED_ERR: 6, NO_MODIFICATION_ALLOWED_ERR: 7, NOT_FOUND_ERR: 8, NOT_SUPPORTED_ERR: 9 ...}
> 
> 
> [object Error]{description: "Error parsi...", message: "Error parsi...", name: "Error", stack: "Error: Erro..."}
> 
> XML5660: The specified prefix has not been declared. Line: 1, Column 282

