### PR TITLE
Fix breaking change related to "isOriginalDefault"

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,15 +259,21 @@ Vue.use(svgicon, {
 
 ### isStroke
 
-Is use stroke style by default
-
-### isOriginalDefault
-
-Is use original color by default.
+Use stroke style by default
 
 ```js
 Vue.use(svgicon, {
     isStroke: true
+})
+```
+
+### isOriginalDefault
+
+Use original color by default.
+
+```js
+Vue.use(svgicon, {
+    isOriginalDefault: false
 })
 ```
 

--- a/src/components/SvgIcon.vue
+++ b/src/components/SvgIcon.vue
@@ -40,7 +40,7 @@ export default {
         original: {
             type: Boolean,
             default: function() {
-                return !isOriginalDefault
+                return isOriginalDefault
             }
         },
         title: String
@@ -228,6 +228,7 @@ export default {
         }
 
         isStroke = !!options.isStroke
+        isOriginalDefault = !!options.isOriginalDefault
 
         // default size
         options.defaultWidth && (defaultWidth = options.defaultWidth)


### PR DESCRIPTION
This fixes a breaking change introduced in [this commit](https://github.com/MMF-FE/vue-svgicon/commit/6be9fdb06cc30ae5d27285fe886bb02c7ac6227b).

The `original` value was changed from `false` to `true`.
Also, the new `isOriginalDefault` option did not work since it did not overwrite the value in the `install` method.